### PR TITLE
fail with error on missing subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ It supports AWS SSO login (via `aws-vault`) to fetch the CodeArtifact authentica
 ## Usage
 
 1. Install somewhere on your system using
-```
-    pip3 install git+ssh://git@github.com/cultureamp/poetry-codeartifact-auth.git
-```
 
-(you will need [Github SSH Authentication](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) set up already. Alternatively you can probably set up HTTPS authentication use the `https` URL). See notes below about package publication status. The intent is to install this globally (but if you have global dependency conflicts you could create a custom virtual environment and set up a command alias to run in the virtual environment. This is likely not needed though).
+    pip3 install git+https://github.com/cultureamp/poetry-codeartifact-auth.git
+
+See notes below about package publication status. The intent is to install this globally (but if you have global dependency conflicts you could create a custom virtual environment and set up a command alias to run in the virtual environment. This is likely not needed though).
 
 2. If not already added, add the CodeArtifact repository URL to your `pyproject.toml`. The URL will look something like `https://yourorg-python-ci-12346789012.d.codeartifact.us-west-2.amazonaws.com/pypi/some-named-private-python-repo/simple`. Follow Poetry's [instructions](https://python-poetry.org/docs/repositories/#secondary-package-sources) for adding this. The CodeArtifact `domain`, `domainOwner` (AWS account ID) and `region` are inferred from the repository URL when fetching auth credentials.
 
@@ -111,5 +110,5 @@ Tests can be run with `pytest`.
 
 ## Availability on Public Repositories
 
-This package would likely be suitable to release publicly and publish on PyPI, however we have not yet set up the publication pipeline for this. As it is a standalone tool, and not something that third party code should depend on directly, it should not be a problem to install directly from a Git SSH URL.
+This package would likely be suitable to release publicly and publish on PyPI, however we have not yet set up the publication pipeline for this. As it is a standalone tool, and not something that third party code should depend on directly, it should not be a problem to install directly from a Github URL.
 

--- a/poetry_codeartifact_auth.py
+++ b/poetry_codeartifact_auth.py
@@ -374,7 +374,7 @@ def main():
         default=_DEFAULT_DURATION_SECONDS / 60,
         help="Lifetime of token. Make this as short as practical unless it is being stored securely",
     )
-    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     subparsers.add_parser(
         "refresh", help="refresh CodeArtifact authentication token in Poetry config"
@@ -436,6 +436,8 @@ def main():
             write_auth_to_dotenv(
                 auth_config, parsed.file, create=parsed.create, export=parsed.export
             )
+        else:
+            raise ValueError("You must specify a valid subcommand")
 
 
 if __name__ == "__main__":

--- a/tests/test_poetry_codeartifact_auth.py
+++ b/tests/test_poetry_codeartifact_auth.py
@@ -1,5 +1,7 @@
 # pylint:disable=missing-docstring
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +11,7 @@ from poetry_codeartifact_auth import (
     CodeArtifactUrlParseException,
     _find_pyproject_toml_path,
     _get_repo_config_from_pyproject_toml,
+    main,
 )
 
 
@@ -56,3 +59,15 @@ class TestCodeArtifactRepoConfig:
 def test_parse_poetry_repo_config():
     config_output = "{'example': {'url': 'https://repo.example.com'}}"
     assert parse_poetry_repo_config(config_output)["example"]["url"] == "https://repo.example.com"
+
+
+def test__cli_fails_without_subcommand():
+    with patch.object(sys, "argv", ["poetry-ca-auth"]):
+        with pytest.raises(SystemExit):
+            main()
+
+
+def test__cli_fails_with_invalid_subcommand():
+    with patch.object(sys, "argv", ["poetry-ca-auth", "banana"]):
+        with pytest.raises(SystemExit):
+            main()


### PR DESCRIPTION
we should fail hard when users don't provide a subcommand