### PR TITLE
[v0.4.1] fix handling of missing auth vars

### DIFF
--- a/poetry_codeartifact_auth.py
+++ b/poetry_codeartifact_auth.py
@@ -238,7 +238,9 @@ class AuthConfig:
             try:
                 AwsAuthParameters.from_env_auth_vars(dict(os.environ))
             except MissingAuthVarsException as exc:
-                raise CodeArtifactAuthConfigException() from exc
+                raise CodeArtifactAuthConfigException(
+                    "AWS_* authentication vars must be set"
+                ) from exc
 
     def profile_for_repo(self, repo_name: str):
         """Get the profile for the provided repository name"""

--- a/poetry_codeartifact_auth.py
+++ b/poetry_codeartifact_auth.py
@@ -215,6 +215,10 @@ class AwsAuthMethod(Enum):
     SSO = "sso"
 
 
+class CodeArtifactAuthConfigException(ValueError):
+    """The authentication configuration is invalid"""
+
+
 @dataclass(frozen=True)
 class AuthConfig:
     """Configuration for authenticating against AWS"""
@@ -223,6 +227,18 @@ class AuthConfig:
     default_profile: str = ""
     duration_seconds: int = _DEFAULT_DURATION_SECONDS
     profile_overrides: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.method in (AwsAuthMethod.VAULT, AwsAuthMethod.SSO):
+            if not self.default_profile:
+                raise CodeArtifactAuthConfigException(
+                    f"AWS default profile must be set for authentication method {self.method}"
+                )
+        elif self.method == AwsAuthMethod.ENV:
+            try:
+                AwsAuthParameters.from_env_auth_vars(dict(os.environ))
+            except MissingAuthVarsException as exc:
+                raise CodeArtifactAuthConfigException() from exc
 
     def profile_for_repo(self, repo_name: str):
         """Get the profile for the provided repository name"""

--- a/poetry_codeartifact_auth_plugin.py
+++ b/poetry_codeartifact_auth_plugin.py
@@ -7,7 +7,12 @@ from poetry.console.application import Application
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
 
-from poetry_codeartifact_auth import poetry_repositories, auth_config_from_env, refresh_all_auth
+from poetry_codeartifact_auth import (
+    poetry_repositories,
+    auth_config_from_env,
+    refresh_all_auth,
+    CodeArtifactAuthConfigException,
+)
 
 
 class CAAuthPlugin(ApplicationPlugin):
@@ -36,11 +41,13 @@ class CAAuthPlugin(ApplicationPlugin):
             )
             return
 
-        auth_config = auth_config_from_env()
-        if not auth_config.default_profile:
+        try:
+            auth_config = auth_config_from_env()
+        except CodeArtifactAuthConfigException as exc:
             event.io.write_error(
-                "AWS profile must be configured using `POETRY_CA_DEFAULT_AWS_PROFILE` environment variable. "
-                "Plugin will not function"
+                f"{exc!r}. AWS profile must be configured using `POETRY_CA_DEFAULT_AWS_PROFILE` or "
+                f"`POETRY_CA_AUTH_METHOD` env var must be set to `none` or `environment`. "
+                f"CodeArtifact auth plugin will not function"
             )
             return
         refresh_all_auth(auth_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-codeartifact-auth"
-version = "0.4.0"
+version = "0.4.1"
 description = "Authenticates against AWS CodeArtifact"
 authors = ["andy.mackinlay <admackin@noreply.github.com>"]
 packages = [


### PR DESCRIPTION
This updates to handle auth vars better, particularly when authenticating using `environment` (previously it would fail if the profile was not set even though it is not needed)