### PR TITLE
v0.5.2: fix inifinite loop resolving pyproject.toml

### DIFF
--- a/poetry_codeartifact_auth.py
+++ b/poetry_codeartifact_auth.py
@@ -174,13 +174,15 @@ def parse_poetry_repo_config(poetry_output: str) -> Dict[str, _PoetryRepoConfig]
 
 def _find_pyproject_toml_path(cwd: str = None):
     fs_path = Path(cwd or os.getcwd())
+    root = Path(fs_path.root)
 
     def toml_path():
         return fs_path / "pyproject.toml"
 
     while not toml_path().exists():
+        LOG.debug(f"no_file_found_at_path_trying_parent path={toml_path()}")
         fs_path = fs_path.parent
-        if fs_path == fs_path.root:
+        if fs_path == root:
             raise MissingPyprojectTomlFile(
                 "Hit root directory while attempting to find pyproject.toml"
             )

--- a/poetry_codeartifact_auth.py
+++ b/poetry_codeartifact_auth.py
@@ -179,10 +179,15 @@ def _find_pyproject_toml_path(cwd: str = None):
     def toml_path():
         return fs_path / "pyproject.toml"
 
+    count = 0
+
     while not toml_path().exists():
         LOG.debug(f"no_file_found_at_path_trying_parent path={toml_path()}")
         fs_path = fs_path.parent
-        if fs_path == root:
+        count += 1
+        # if the root check fails we get stuck in an
+        # infinite loop, so have a failsafe
+        if fs_path == root or count > 1000:
             raise MissingPyprojectTomlFile(
                 "Hit root directory while attempting to find pyproject.toml"
             )

--- a/poetry_codeartifact_auth_plugin.py
+++ b/poetry_codeartifact_auth_plugin.py
@@ -5,6 +5,7 @@ from cleo.events.console_events import COMMAND
 from cleo.events.event_dispatcher import EventDispatcher
 from poetry.console.application import Application
 from poetry.console.commands.installer_command import InstallerCommand
+from poetry.console.commands.self.self_command import SelfCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
 
 from poetry_codeartifact_auth import (
@@ -33,6 +34,10 @@ class CAAuthPlugin(ApplicationPlugin):
         """Refresh the authentication token if it is an install-type event"""
         command = event.command
         if not isinstance(command, InstallerCommand):
+            return
+        if isinstance(command, SelfCommand):
+            # self commands should work w/o TOML file and don't need this unless you want
+            # to install private plugins
             return
         if not poetry_repositories():
             event.io.write_line(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-codeartifact-auth"
-version = "0.5.1"
+version = "0.5.2"
 description = "Authenticates against AWS CodeArtifact"
 authors = ["andy.mackinlay <admackin@noreply.github.com>"]
 packages = [


### PR DESCRIPTION
* Fixes an issue where running `poetry` outside a project directory would lead to an infinite loop
* For poetry plugin: don't bother trying to find `pyproject.toml` for `self` commands